### PR TITLE
Add Tweet embed component and preview flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Tweet/X embed preview
+
+- `components/TweetEmbed/TweetEmbed.tsx` exposes a reusable client component that turns a Twitter/X URL into the official embed. It loads the widget script lazily, shows a loader, and surfaces clear error messages for invalid, private, or missing tweets.
+- `components/TweetEmbed/TweetEmbedField.tsx` provides a ready-made field with the label "Coller le lien du post" and live preview handling. The page `app/embed/page.tsx` renders this field so you can test the flow end to end.
+
+Manual checks:
+
+1. Paste a valid, public tweet URL (e.g., `https://x.com/TwitterDev/status/560070183650213889`) and verify the embed renders.
+2. Paste a non-Twitter/X URL to see the validation error.
+3. Paste a private or removed tweet URL to trigger the "Ce tweet ne peut pas être affiché" message.
+4. Observe the loader while the widget script initializes.
+
 ## Getting Started
 
 First, run the development server:

--- a/app/embed/page.tsx
+++ b/app/embed/page.tsx
@@ -1,0 +1,9 @@
+import { TweetEmbedField } from '@/components/TweetEmbed/TweetEmbedField'
+
+export default function EmbedTweetPage() {
+  return (
+    <main className='flex min-h-screen w-full items-center justify-center bg-background px-6 py-12'>
+      <TweetEmbedField />
+    </main>
+  )
+}

--- a/components/TweetEmbed/README.md
+++ b/components/TweetEmbed/README.md
@@ -1,0 +1,41 @@
+# TweetEmbed
+
+Composant client React pour prévisualiser un tweet/X à partir d'une URL collée par l'utilisateur. Il repose sur le widget officiel Twitter/X et charge le script `https://platform.twitter.com/widgets.js` uniquement lorsqu'une URL compatible est fournie.
+
+## Utilisation rapide
+
+```tsx
+import { TweetEmbed } from '@/components/TweetEmbed/TweetEmbed'
+
+<TweetEmbed url="https://x.com/username/status/123456" />
+```
+
+- `url` : lien complet du tweet à afficher (`https://x.com/.../status/<id>` ou `https://twitter.com/.../status/<id>`).
+- `className` : classes utilitaires additionnelles si besoin.
+
+Le composant affiche automatiquement :
+
+- Un message d'aide tant qu'aucun lien n'est fourni.
+- Un loader pendant le rendu du widget.
+- Un message d'erreur explicite si l'URL est invalide ou si le tweet est privé/supprimé.
+
+## Champ de saisie prêt à l'emploi
+
+Le composant `TweetEmbedField` couple un champ "Coller le lien du post" et la prévisualisation :
+
+```tsx
+import { TweetEmbedField } from '@/components/TweetEmbed/TweetEmbedField'
+
+<TweetEmbedField onSubmit={(url) => console.log('URL soumise', url)} />
+```
+
+Ce composant est utilisé sur la page `/embed` (voir `app/embed/page.tsx`) pour valider l'intégration visuelle et l'UX.
+
+## Cas de test manuels
+
+1. **URL valide** : collez une URL publique (ex. `https://x.com/TwitterDev/status/560070183650213889`) et vérifiez l'apparition du tweet avec ses médias.
+2. **URL invalide ou hors Twitter/X** : collez un lien qui n'est pas un statut ; la prévisualisation affiche un message indiquant que l'URL n'est pas reconnue.
+3. **Tweet privé/supprimé** : utilisez un tweet non public ; après le chargement, un message signale que le tweet ne peut pas être affiché.
+4. **Chargement** : observez le spinner pendant la récupération du widget.
+
+Ces scénarios couvrent les états principaux : aide initiale, succès d'embed, erreur d'URL et erreur de disponibilité du tweet.

--- a/components/TweetEmbed/TweetEmbed.tsx
+++ b/components/TweetEmbed/TweetEmbed.tsx
@@ -1,0 +1,197 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { AlertTriangle, Loader2 } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+const SUPPORTED_HOSTNAMES = new Set(['x.com', 'www.x.com', 'twitter.com', 'www.twitter.com'])
+
+let twitterScriptPromise: Promise<void> | null = null
+
+const loadTwitterWidgets = () => {
+  if (typeof window === 'undefined') return Promise.resolve()
+
+  if (window.twttr?.widgets) {
+    return Promise.resolve()
+  }
+
+  if (twitterScriptPromise) return twitterScriptPromise
+
+  twitterScriptPromise = new Promise<void>((resolve, reject) => {
+    const existingScript = document.querySelector(
+      'script[src="https://platform.twitter.com/widgets.js"]',
+    ) as HTMLScriptElement | null
+
+    if (existingScript) {
+      existingScript.addEventListener('load', () => resolve(), { once: true })
+      existingScript.addEventListener('error', () => reject(new Error('Twitter widgets failed to load')), {
+        once: true,
+      })
+      return
+    }
+
+    const script = document.createElement('script')
+    script.async = true
+    script.src = 'https://platform.twitter.com/widgets.js'
+    script.charset = 'utf-8'
+    script.onload = () => resolve()
+    script.onerror = () => reject(new Error('Twitter widgets failed to load'))
+
+    document.body.appendChild(script)
+  })
+
+  return twitterScriptPromise
+}
+
+const getTweetIdFromUrl = (url: string) => {
+  try {
+    const parsed = new URL(url)
+    if (!SUPPORTED_HOSTNAMES.has(parsed.hostname.toLowerCase())) {
+      return null
+    }
+
+    const segments = parsed.pathname.split('/').filter(Boolean)
+    const statusIndex = segments.indexOf('status')
+
+    if (statusIndex === -1 || statusIndex === segments.length - 1) {
+      return null
+    }
+
+    const tweetId = segments[statusIndex + 1]?.split('?')[0]
+
+    return /^\d+$/.test(tweetId) ? tweetId : null
+  } catch (error) {
+    console.error('Invalid Twitter/X URL', error)
+    return null
+  }
+}
+
+const TWITTER_ERROR_MESSAGE = 'Ce tweet ne peut pas être affiché (post privé ou inexistant).'
+const INVALID_URL_MESSAGE = "L'URL fournie n'est pas reconnue comme un lien Twitter/X."
+
+type TweetEmbedProps = {
+  url?: string
+  className?: string
+}
+
+export const TweetEmbed = ({ url, className }: TweetEmbedProps) => {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const tweetId = useMemo(() => {
+    if (!url) return null
+    return getTweetIdFromUrl(url)
+  }, [url])
+
+  useEffect(() => {
+    let isCancelled = false
+    const container = containerRef.current
+
+    if (!container) return
+
+    container.innerHTML = ''
+
+    if (!url) {
+      setErrorMessage(null)
+      setIsLoading(false)
+      return
+    }
+
+    if (!tweetId) {
+      setErrorMessage(INVALID_URL_MESSAGE)
+      setIsLoading(false)
+      return
+    }
+
+    const renderTweet = async () => {
+      setErrorMessage(null)
+      setIsLoading(true)
+
+      try {
+        await loadTwitterWidgets()
+
+        if (isCancelled || !containerRef.current) return
+
+        const result = await window.twttr?.widgets?.createTweet(tweetId, containerRef.current, {
+          align: 'center',
+        })
+
+        if (!result && !isCancelled) {
+          setErrorMessage(TWITTER_ERROR_MESSAGE)
+        }
+      } catch (error) {
+        console.error(error)
+        if (!isCancelled) {
+          setErrorMessage(TWITTER_ERROR_MESSAGE)
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    renderTweet()
+
+    return () => {
+      isCancelled = true
+      if (containerRef.current) {
+        containerRef.current.innerHTML = ''
+      }
+    }
+  }, [tweetId, url])
+
+  const showPlaceholder = !url || !tweetId
+
+  return (
+    <div className={cn('relative w-full', className)}>
+      {showPlaceholder && !errorMessage && (
+        <div className='border rounded-xl border-border bg-muted/40 text-muted-foreground p-4 text-sm'>
+          Collez un lien Twitter/X pour voir un aperçu du tweet.
+        </div>
+      )}
+
+      {errorMessage && (
+        <div className='border rounded-xl border-destructive/30 bg-destructive/10 text-destructive p-4 text-sm flex gap-2'>
+          <AlertTriangle className='h-5 w-5 shrink-0' aria-hidden />
+          <p>{errorMessage}</p>
+        </div>
+      )}
+
+      <div
+        ref={containerRef}
+        className={cn(
+          'min-h-[200px] w-full',
+          (isLoading || errorMessage || showPlaceholder) && 'flex items-center justify-center',
+        )}
+        aria-busy={isLoading}
+      />
+
+      {isLoading && (
+        <div className='absolute inset-0 flex items-center justify-center pointer-events-none'>
+          <div className='flex items-center gap-2 rounded-full bg-background/70 px-3 py-2 shadow-sm'>
+            <Loader2 className='h-4 w-4 animate-spin' />
+            <span className='text-sm'>Chargement du tweet…</span>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+declare global {
+  interface Window {
+    twttr?: {
+      widgets?: {
+        createTweet: (
+          tweetId: string,
+          element: HTMLElement,
+          options?: Record<string, unknown>,
+        ) => Promise<HTMLElement | void>
+        load: (element?: HTMLElement) => void
+      }
+    }
+  }
+}

--- a/components/TweetEmbed/TweetEmbedField.tsx
+++ b/components/TweetEmbed/TweetEmbedField.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { FormEvent, useState } from 'react'
+
+import { cn } from '@/lib/utils'
+
+import { Button } from '../ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { TweetEmbed } from './TweetEmbed'
+
+type TweetEmbedFieldProps = {
+  className?: string
+  defaultUrl?: string
+  onSubmit?: (url: string) => void
+}
+
+export const TweetEmbedField = ({ className, defaultUrl = '', onSubmit }: TweetEmbedFieldProps) => {
+  const [draftUrl, setDraftUrl] = useState(defaultUrl)
+  const [previewUrl, setPreviewUrl] = useState(defaultUrl)
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const nextUrl = draftUrl.trim()
+    setPreviewUrl(nextUrl)
+    onSubmit?.(nextUrl)
+  }
+
+  return (
+    <Card className={cn('w-full max-w-2xl', className)}>
+      <CardHeader>
+        <CardTitle>Coller le lien du post</CardTitle>
+        <CardDescription>
+          Ajoutez une URL Twitter/X (ex. https://x.com/username/status/123456) pour prévisualiser le tweet avant
+          de la soumettre.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className='flex flex-col gap-4'>
+        <form className='flex flex-col gap-3' onSubmit={handleSubmit}>
+          <div className='flex flex-col gap-2'>
+            <Label htmlFor='tweet-url'>Lien du post</Label>
+            <div className='flex flex-col gap-3 sm:flex-row'>
+              <Input
+                id='tweet-url'
+                value={draftUrl}
+                onChange={(event) => setDraftUrl(event.target.value)}
+                placeholder='https://x.com/username/status/123456'
+                inputMode='url'
+                className='flex-1'
+              />
+              <Button type='submit' className='sm:w-36'>
+                Prévisualiser
+              </Button>
+            </div>
+            <p className='text-xs text-muted-foreground'>Seuls les liens Twitter/X publics sont pris en charge.</p>
+          </div>
+        </form>
+
+        <TweetEmbed url={previewUrl} />
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable TweetEmbed component that lazy-loads the Twitter/X widget, shows loading state, and reports errors for invalid or unavailable tweets
- provide a TweetEmbedField form and embed preview page to let users paste a link and validate the rendered tweet
- document usage patterns and manual test cases for embedding tweets

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f7854d0c88322bd85b7a2ffac6520)