### PR TITLE
Add Spotify and SoundCloud embed widgets

### DIFF
--- a/app/api/meta-oembed/route.ts
+++ b/app/api/meta-oembed/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { createClient } from '@/utils/supabase/server'
+
+const bodySchema = z.object({
+  url: z.string().url(),
+})
+
+const detectPlatformFromUrl = (rawUrl: string): 'instagram' | 'facebook' | null => {
+  const normalized = rawUrl.toLowerCase()
+
+  if (normalized.includes('instagram.com')) return 'instagram'
+  if (normalized.includes('facebook.com') || normalized.includes('fb.watch')) return 'facebook'
+
+  return null
+}
+
+const metaAccessToken = process.env.META_OEMBED_APP_TOKEN
+const restrictedMode = process.env.META_OEMBED_RESTRICTED === 'true'
+const allowedTesters = (process.env.META_OEMBED_TESTER_EMAILS ?? '')
+  .split(',')
+  .map((value) => value.trim().toLowerCase())
+  .filter(Boolean)
+
+export async function POST(request: Request) {
+  const json = await request.json().catch(() => null)
+  const parsed = bodySchema.safeParse(json)
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'URL manquante ou invalide.' }, { status: 400 })
+  }
+
+  const { url } = parsed.data
+  const platform = detectPlatformFromUrl(url)
+
+  if (!platform) {
+    return NextResponse.json(
+      { error: 'Seuls les liens Instagram ou Facebook sont acceptés.' },
+      { status: 400 },
+    )
+  }
+
+  if (!metaAccessToken) {
+    return NextResponse.json(
+      { error: "Jeton oEmbed Meta non configuré côté serveur. Ajoutez META_OEMBED_APP_TOKEN." },
+      { status: 500 },
+    )
+  }
+
+  if (restrictedMode) {
+    const supabase = await createClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json(
+        { error: 'Fonctionnalité limitée aux comptes testeurs connectés pendant la phase de validation.' },
+        { status: 403 },
+      )
+    }
+
+    if (allowedTesters.length > 0) {
+      const email = user.email?.toLowerCase() ?? ''
+      if (!allowedTesters.includes(email)) {
+        return NextResponse.json(
+          {
+            error:
+              'Accès restreint aux testeurs ajoutés dans META_OEMBED_TESTER_EMAILS tant que la review Meta n\'est pas validée.',
+          },
+          { status: 403 },
+        )
+      }
+    }
+  }
+
+  const endpoint =
+    platform === 'instagram'
+      ? 'https://graph.facebook.com/v12.0/instagram_oembed'
+      : 'https://graph.facebook.com/v12.0/facebook_oembed'
+
+  const searchParams = new URLSearchParams({
+    url,
+    access_token: metaAccessToken,
+    omitscript: 'false',
+  })
+
+  const response = await fetch(`${endpoint}?${searchParams.toString()}`, {
+    cache: 'no-store',
+  })
+
+  const payload = await response.json().catch(() => null)
+
+  if (!response.ok || !payload?.html) {
+    const message = payload?.error?.message ?? payload?.message
+    const fallbackError =
+      "Impossible de récupérer le code d'intégration Meta. Le post est peut-être privé ou votre compte non autorisé."
+
+    const status = response.status === 401 || response.status === 403 ? 403 : 400
+    return NextResponse.json({ error: message ?? fallbackError }, { status })
+  }
+
+  return NextResponse.json({ html: payload.html as string, platform })
+}

--- a/app/embed/page.tsx
+++ b/app/embed/page.tsx
@@ -1,5 +1,6 @@
 import { AudioEmbedField } from '@/components/AudioEmbed/AudioEmbedField'
 import { TweetEmbedField } from '@/components/TweetEmbed/TweetEmbedField'
+import { VideoEmbedField } from '@/components/VideoPlayer/VideoEmbedField'
 
 export default function EmbedPage() {
   return (
@@ -7,15 +8,16 @@ export default function EmbedPage() {
       <div className='flex w-full max-w-6xl flex-col gap-8'>
         <header className='space-y-2'>
           <p className='text-sm font-medium text-muted-foreground uppercase tracking-wide'>Prévisualisation des refs</p>
-          <h1 className='text-3xl font-semibold leading-tight'>Tweets, tracks Spotify ou playlists SoundCloud en un copier/coller</h1>
+          <h1 className='text-3xl font-semibold leading-tight'>Tweets, vidéos et tracks en un copier/coller</h1>
           <p className='text-muted-foreground'>
-            Collez l&apos;URL officielle et nous affichons automatiquement le widget embarqué pour que la ref soit visible
-            immédiatement dans le feed.
+            Collez l&apos;URL officielle (TikTok, YouTube, lien vidéo, tweet, Spotify, SoundCloud) et nous affichons
+            automatiquement le widget embarqué pour que la ref soit visible immédiatement dans le feed.
           </p>
         </header>
 
-        <div className='grid gap-6 lg:grid-cols-2'>
+        <div className='grid gap-6 lg:grid-cols-2 xl:grid-cols-3'>
           <TweetEmbedField className='h-full' />
+          <VideoEmbedField className='h-full' />
           <AudioEmbedField className='h-full' />
         </div>
       </div>

--- a/app/embed/page.tsx
+++ b/app/embed/page.tsx
@@ -1,9 +1,24 @@
+import { AudioEmbedField } from '@/components/AudioEmbed/AudioEmbedField'
 import { TweetEmbedField } from '@/components/TweetEmbed/TweetEmbedField'
 
-export default function EmbedTweetPage() {
+export default function EmbedPage() {
   return (
     <main className='flex min-h-screen w-full items-center justify-center bg-background px-6 py-12'>
-      <TweetEmbedField />
+      <div className='flex w-full max-w-6xl flex-col gap-8'>
+        <header className='space-y-2'>
+          <p className='text-sm font-medium text-muted-foreground uppercase tracking-wide'>Prévisualisation des refs</p>
+          <h1 className='text-3xl font-semibold leading-tight'>Tweets, tracks Spotify ou playlists SoundCloud en un copier/coller</h1>
+          <p className='text-muted-foreground'>
+            Collez l&apos;URL officielle et nous affichons automatiquement le widget embarqué pour que la ref soit visible
+            immédiatement dans le feed.
+          </p>
+        </header>
+
+        <div className='grid gap-6 lg:grid-cols-2'>
+          <TweetEmbedField className='h-full' />
+          <AudioEmbedField className='h-full' />
+        </div>
+      </div>
     </main>
   )
 }

--- a/app/embed/page.tsx
+++ b/app/embed/page.tsx
@@ -1,6 +1,7 @@
 import { AudioEmbedField } from '@/components/AudioEmbed/AudioEmbedField'
 import { TweetEmbedField } from '@/components/TweetEmbed/TweetEmbedField'
 import { VideoEmbedField } from '@/components/VideoPlayer/VideoEmbedField'
+import { MetaEmbedField } from '@/components/MetaEmbed/MetaEmbed'
 
 export default function EmbedPage() {
   return (
@@ -10,15 +11,16 @@ export default function EmbedPage() {
           <p className='text-sm font-medium text-muted-foreground uppercase tracking-wide'>Prévisualisation des refs</p>
           <h1 className='text-3xl font-semibold leading-tight'>Tweets, vidéos et tracks en un copier/coller</h1>
           <p className='text-muted-foreground'>
-            Collez l&apos;URL officielle (TikTok, YouTube, lien vidéo, tweet, Spotify, SoundCloud) et nous affichons
-            automatiquement le widget embarqué pour que la ref soit visible immédiatement dans le feed.
+            Collez l&apos;URL officielle (TikTok, YouTube, vidéo, tweet, Spotify, SoundCloud, Instagram, Facebook) et nous
+            affichons automatiquement le widget embarqué pour que la ref soit visible immédiatement dans le feed.
           </p>
         </header>
 
-        <div className='grid gap-6 lg:grid-cols-2 xl:grid-cols-3'>
+        <div className='grid gap-6 lg:grid-cols-2 xl:grid-cols-4'>
           <TweetEmbedField className='h-full' />
           <VideoEmbedField className='h-full' />
           <AudioEmbedField className='h-full' />
+          <MetaEmbedField className='h-full' />
         </div>
       </div>
     </main>

--- a/components/AudioEmbed/AudioEmbedField.tsx
+++ b/components/AudioEmbed/AudioEmbedField.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { FormEvent, KeyboardEvent, useMemo, useState } from 'react'
+import { AlertTriangle, Hash } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+import { Button } from '../ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { Textarea } from '../ui/textarea'
+import { Badge } from '../ui/badge'
+import { SpotifyEmbed } from './SpotifyEmbed'
+import { SoundCloudEmbed } from './SoundCloudEmbed'
+
+type SupportedPlatform = 'spotify' | 'soundcloud'
+
+type AudioEmbedFieldProps = {
+  className?: string
+  defaultUrl?: string
+  defaultNote?: string
+  defaultTags?: string[]
+  onSubmit?: (payload: { url: string; platform: SupportedPlatform | null; note: string; tags: string[] }) => void
+}
+
+const detectPlatformFromUrl = (rawUrl: string): SupportedPlatform | null => {
+  const normalized = rawUrl.toLowerCase()
+
+  if (normalized.includes('open.spotify.com') || normalized.includes('spotify.link')) {
+    return 'spotify'
+  }
+
+  if (normalized.includes('soundcloud.com')) {
+    return 'soundcloud'
+  }
+
+  return null
+}
+
+export const AudioEmbedField = ({
+  className,
+  defaultUrl = '',
+  defaultNote = '',
+  defaultTags = [],
+  onSubmit,
+}: AudioEmbedFieldProps) => {
+  const [draftUrl, setDraftUrl] = useState(defaultUrl)
+  const [previewUrl, setPreviewUrl] = useState(defaultUrl)
+  const [note, setNote] = useState(defaultNote)
+  const [tags, setTags] = useState<string[]>(defaultTags)
+  const [tagDraft, setTagDraft] = useState('')
+
+  const platform = useMemo(() => detectPlatformFromUrl(previewUrl), [previewUrl])
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const nextUrl = draftUrl.trim()
+    const nextPlatform = detectPlatformFromUrl(nextUrl)
+    setPreviewUrl(nextUrl)
+    onSubmit?.({ url: nextUrl, platform: nextPlatform, note, tags })
+  }
+
+  const handleTagAdd = () => {
+    const trimmed = tagDraft.trim()
+    if (!trimmed) return
+
+    if (!tags.includes(trimmed)) {
+      setTags((previous) => [...previous, trimmed])
+    }
+
+    setTagDraft('')
+  }
+
+  const handleTagKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' || event.key === ',') {
+      event.preventDefault()
+      handleTagAdd()
+    }
+  }
+
+  const handleTagRemove = (value: string) => {
+    setTags((previous) => previous.filter((tag) => tag !== value))
+  }
+
+  const unsupportedUrl = previewUrl && !platform
+
+  return (
+    <Card className={cn('w-full max-w-3xl', className)}>
+      <CardHeader>
+        <CardTitle>Coller le lien du morceau / playlist</CardTitle>
+        <CardDescription>
+          Collez une URL Spotify ou SoundCloud (morceau, playlist, album). Nous générons automatiquement le widget officiel
+          pour prévisualiser la ref avant de la publier.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className='flex flex-col gap-6'>
+        <form className='flex flex-col gap-4' onSubmit={handleSubmit}>
+          <div className='flex flex-col gap-2'>
+            <Label htmlFor='audio-url'>Lien du morceau / playlist / album</Label>
+            <div className='flex flex-col gap-3 sm:flex-row'>
+              <Input
+                id='audio-url'
+                value={draftUrl}
+                onChange={(event) => setDraftUrl(event.target.value)}
+                placeholder='https://open.spotify.com/track/... ou https://soundcloud.com/artist/track'
+                inputMode='url'
+                className='flex-1'
+              />
+              <Button type='submit' className='sm:w-40'>
+                Prévisualiser
+              </Button>
+            </div>
+            <p className='text-xs text-muted-foreground'>Les liens publics Spotify/SoundCloud sont acceptés.</p>
+          </div>
+
+          <div className='flex flex-col gap-2'>
+            <Label htmlFor='note'>Note perso</Label>
+            <Textarea
+              id='note'
+              value={note}
+              onChange={(event) => setNote(event.target.value)}
+              placeholder='Pourquoi cette track est une ref ?'
+              rows={3}
+            />
+          </div>
+
+          <div className='flex flex-col gap-2'>
+            <Label htmlFor='tags'>Tags</Label>
+            <div className='flex flex-col gap-2'>
+              <div className='flex flex-col gap-3 sm:flex-row'>
+                <div className='relative flex-1'>
+                  <Hash className='absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground' />
+                  <Input
+                    id='tags'
+                    value={tagDraft}
+                    onChange={(event) => setTagDraft(event.target.value.replace(/,/g, ''))}
+                    onKeyDown={handleTagKeyDown}
+                    placeholder='musique, trendSound, vibe...'
+                    className='pl-9'
+                  />
+                </div>
+                <Button type='button' variant='secondary' className='sm:w-40' onClick={handleTagAdd}>
+                  Ajouter le tag
+                </Button>
+              </div>
+
+              {tags.length > 0 && (
+                <div className='flex flex-wrap gap-2'>
+                  {tags.map((tag) => (
+                    <Badge key={tag} variant='secondary' className='gap-2'>
+                      #{tag}
+                      <button type='button' className='text-xs text-muted-foreground hover:text-foreground' onClick={() => handleTagRemove(tag)}>
+                        ✕
+                      </button>
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </form>
+
+        {unsupportedUrl && (
+          <div className='border rounded-xl border-destructive/30 bg-destructive/10 text-destructive p-4 text-sm flex gap-2'>
+            <AlertTriangle className='h-5 w-5 shrink-0' aria-hidden />
+            <p>Lien non supporté. Merci d&apos;utiliser un URL Spotify ou SoundCloud public.</p>
+          </div>
+        )}
+
+        {platform === 'spotify' && <SpotifyEmbed url={previewUrl} />}
+        {platform === 'soundcloud' && <SoundCloudEmbed url={previewUrl} />}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/AudioEmbed/AudioEmbedField.tsx
+++ b/components/AudioEmbed/AudioEmbedField.tsx
@@ -21,7 +21,12 @@ type AudioEmbedFieldProps = {
   defaultUrl?: string
   defaultNote?: string
   defaultTags?: string[]
-  onSubmit?: (payload: { url: string; platform: SupportedPlatform | null; note: string; tags: string[] }) => void
+  onSubmit?: (payload: {
+    url: string
+    platform: SupportedPlatform | null
+    note: string
+    tags: string[]
+  }) => void
 }
 
 const detectPlatformFromUrl = (rawUrl: string): SupportedPlatform | null => {
@@ -90,8 +95,8 @@ export const AudioEmbedField = ({
       <CardHeader>
         <CardTitle>Coller le lien du morceau / playlist</CardTitle>
         <CardDescription>
-          Collez une URL Spotify ou SoundCloud (morceau, playlist, album). Nous générons automatiquement le widget officiel
-          pour prévisualiser la ref avant de la publier.
+          Collez une URL Spotify ou SoundCloud (morceau, playlist, album). Nous générons
+          automatiquement le widget officiel pour prévisualiser la ref avant de la publier.
         </CardDescription>
       </CardHeader>
 
@@ -112,7 +117,9 @@ export const AudioEmbedField = ({
                 Prévisualiser
               </Button>
             </div>
-            <p className='text-xs text-muted-foreground'>Les liens publics Spotify/SoundCloud sont acceptés.</p>
+            <p className='text-xs text-muted-foreground'>
+              Les liens publics Spotify/SoundCloud sont acceptés.
+            </p>
           </div>
 
           <div className='flex flex-col gap-2'>
@@ -141,7 +148,12 @@ export const AudioEmbedField = ({
                     className='pl-9'
                   />
                 </div>
-                <Button type='button' variant='secondary' className='sm:w-40' onClick={handleTagAdd}>
+                <Button
+                  type='button'
+                  variant='secondary'
+                  className='sm:w-40'
+                  onClick={handleTagAdd}
+                >
                   Ajouter le tag
                 </Button>
               </div>
@@ -151,7 +163,11 @@ export const AudioEmbedField = ({
                   {tags.map((tag) => (
                     <Badge key={tag} variant='secondary' className='gap-2'>
                       #{tag}
-                      <button type='button' className='text-xs text-muted-foreground hover:text-foreground' onClick={() => handleTagRemove(tag)}>
+                      <button
+                        type='button'
+                        className='text-xs text-muted-foreground hover:text-foreground'
+                        onClick={() => handleTagRemove(tag)}
+                      >
                         ✕
                       </button>
                     </Badge>

--- a/components/AudioEmbed/README.md
+++ b/components/AudioEmbed/README.md
@@ -1,0 +1,49 @@
+# Composants Spotify & SoundCloud Embed
+
+## Vue d'ensemble
+
+Ces composants permettent de prévisualiser un morceau, un album ou une playlist Spotify/SoundCloud à partir d'un simple copier/coller du lien. La logique de détection est basée sur l'URL et utilise les widgets officiels de chaque plateforme.
+
+## Composants
+
+- `SpotifyEmbed`: affiche un iframe `open.spotify.com/embed/{type}/{id}` avec gestion du chargement et des erreurs.
+- `SoundCloudEmbed`: affiche un iframe `w.soundcloud.com/player` avec personnalisation de la couleur.
+- `AudioEmbedField`: champ complet pour coller le lien, ajouter une note perso et des tags, puis prévisualiser automatiquement le widget approprié.
+
+## Utilisation rapide
+
+```tsx
+import { AudioEmbedField } from '@/components/AudioEmbed/AudioEmbedField'
+
+export default function Example() {
+  return <AudioEmbedField />
+}
+```
+
+### Utilisation des embeds seuls
+
+```tsx
+import { SpotifyEmbed } from '@/components/AudioEmbed/SpotifyEmbed'
+import { SoundCloudEmbed } from '@/components/AudioEmbed/SoundCloudEmbed'
+
+<SpotifyEmbed url="https://open.spotify.com/track/0eGsygTp906u18L0Oimnem" />
+<SoundCloudEmbed url="https://soundcloud.com/forss/flickermood" color="#1DB954" />
+```
+
+## Cas de test manuels
+
+Testez les URLs suivantes dans le champ de prévisualisation :
+
+- Spotify track : `https://open.spotify.com/track/0VjIjW4GlUZAMYd2vXMi3b`
+- Spotify playlist : `https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M`
+- Spotify album : `https://open.spotify.com/album/4aawyAB9vmqN3uQ7FjRGTy`
+- SoundCloud track : `https://soundcloud.com/forss/flickermood`
+- SoundCloud playlist : `https://soundcloud.com/johnfogerty/sets/the-long-road-home`
+- Lien non supporté : `https://example.com/foo`
+
+Les liens non publics ou mal formés doivent afficher un message d'erreur, tandis que les liens valides affichent le widget avec un loader pendant le chargement.
+
+## Notes de conformité
+
+- Les lecteurs intégrés utilisent uniquement les widgets officiels Spotify et SoundCloud (aucun scraping ou téléchargement audio).
+- Les iframes sont chargées en `lazy` et encapsulées dans un wrapper responsive pour un rendu desktop/mobile.

--- a/components/AudioEmbed/SoundCloudEmbed.tsx
+++ b/components/AudioEmbed/SoundCloudEmbed.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { AlertTriangle, Loader2 } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+const SOUNDCLOUD_HOSTNAMES = new Set(['soundcloud.com', 'www.soundcloud.com', 'm.soundcloud.com'])
+
+const INVALID_URL_MESSAGE = "L'URL fournie n'est pas reconnue comme un lien SoundCloud valide."
+const UNSUPPORTED_MESSAGE = 'Ce contenu SoundCloud ne peut pas être affiché (lien non public ou non supporté).'
+
+type SoundCloudEmbedProps = {
+  url?: string
+  className?: string
+  color?: string
+  height?: number
+}
+
+const parseSoundCloudUrl = (rawUrl?: string) => {
+  if (!rawUrl) return null
+
+  try {
+    const url = new URL(rawUrl)
+    if (!SOUNDCLOUD_HOSTNAMES.has(url.hostname)) return null
+
+    return url.toString()
+  } catch (error) {
+    console.error('Invalid SoundCloud URL', error)
+    return null
+  }
+}
+
+export const SoundCloudEmbed = ({ url, className, color = '#ff5500', height = 166 }: SoundCloudEmbedProps) => {
+  const [isLoading, setIsLoading] = useState(false)
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const normalizedUrl = useMemo(() => parseSoundCloudUrl(url), [url])
+  const iframeSrc = useMemo(() => {
+    if (!normalizedUrl) return null
+    const encodedUrl = encodeURIComponent(normalizedUrl)
+    const encodedColor = encodeURIComponent(color)
+
+    return `https://w.soundcloud.com/player/?url=${encodedUrl}&color=${encodedColor}`
+  }, [color, normalizedUrl])
+
+  useEffect(() => {
+    if (!url) {
+      setErrorMessage(null)
+      setIsLoading(false)
+      setHasLoadedOnce(false)
+      return
+    }
+
+    if (!normalizedUrl) {
+      setErrorMessage(INVALID_URL_MESSAGE)
+      setIsLoading(false)
+      setHasLoadedOnce(false)
+      return
+    }
+
+    setErrorMessage(null)
+    setIsLoading(true)
+    setHasLoadedOnce(false)
+  }, [normalizedUrl, url])
+
+  return (
+    <div className={cn('relative w-full', className)}>
+      {!url && !errorMessage && (
+        <div className='border rounded-xl border-border bg-muted/40 text-muted-foreground p-4 text-sm'>
+          Collez un lien SoundCloud (piste ou playlist publique) pour voir le lecteur.
+        </div>
+      )}
+
+      {errorMessage && (
+        <div className='border rounded-xl border-destructive/30 bg-destructive/10 text-destructive p-4 text-sm flex gap-2'>
+          <AlertTriangle className='h-5 w-5 shrink-0' aria-hidden />
+          <p>{errorMessage}</p>
+        </div>
+      )}
+
+      {iframeSrc && !errorMessage && (
+        <div className='relative overflow-hidden rounded-xl border border-border bg-card shadow-sm'>
+          <iframe
+            width='100%'
+            height={height}
+            scrolling='no'
+            frameBorder='no'
+            allow='autoplay'
+            src={iframeSrc}
+            className='w-full rounded-xl'
+            title='SoundCloud embed'
+            onLoad={() => {
+              setIsLoading(false)
+              setHasLoadedOnce(true)
+            }}
+            onError={() => {
+              setErrorMessage(UNSUPPORTED_MESSAGE)
+              setIsLoading(false)
+            }}
+          />
+
+          {isLoading && (
+            <div className='absolute inset-0 flex items-center justify-center bg-background/70'>
+              <div className='flex items-center gap-2 rounded-full bg-background/90 px-3 py-2 shadow-sm'>
+                <Loader2 className='h-4 w-4 animate-spin' />
+                <span className='text-sm'>Chargement du player…</span>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {hasLoadedOnce && !isLoading && !iframeSrc && !errorMessage && (
+        <div className='border rounded-xl border-destructive/30 bg-destructive/10 text-destructive p-4 text-sm flex gap-2'>
+          <AlertTriangle className='h-5 w-5 shrink-0' aria-hidden />
+          <p>{UNSUPPORTED_MESSAGE}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/AudioEmbed/SpotifyEmbed.tsx
+++ b/components/AudioEmbed/SpotifyEmbed.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { AlertTriangle, Loader2 } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+const SPOTIFY_HOSTNAMES = new Set([
+  'open.spotify.com',
+  'www.open.spotify.com',
+  'spotify.link',
+  'spotify.app.link',
+])
+
+const SPOTIFY_TYPES = ['track', 'album', 'playlist', 'episode', 'show'] as const
+
+type SpotifyType = (typeof SPOTIFY_TYPES)[number]
+
+type SpotifyEmbedProps = {
+  url?: string
+  className?: string
+  height?: number
+}
+
+const INVALID_URL_MESSAGE = "L'URL fournie n'est pas reconnue comme un lien Spotify valide."
+const UNSUPPORTED_MESSAGE = "Ce contenu Spotify ne peut pas être affiché (type non supporté ou contenu privé)."
+
+const parseSpotifyUrl = (rawUrl?: string): { type: SpotifyType; id: string } | null => {
+  if (!rawUrl) return null
+
+  try {
+    const url = new URL(rawUrl)
+
+    if (!SPOTIFY_HOSTNAMES.has(url.hostname)) return null
+
+    const segments = url.pathname.split('/').filter(Boolean)
+    const type = segments[0] as SpotifyType | undefined
+    const idWithQuery = segments[1]
+
+    if (!type || !SPOTIFY_TYPES.includes(type)) return null
+    if (!idWithQuery) return null
+
+    const id = idWithQuery.split('?')[0]
+
+    return { type, id }
+  } catch (error) {
+    console.error('Invalid Spotify URL', error)
+    return null
+  }
+}
+
+export const SpotifyEmbed = ({ url, className, height }: SpotifyEmbedProps) => {
+  const [isLoading, setIsLoading] = useState(false)
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const parsedUrl = useMemo(() => parseSpotifyUrl(url), [url])
+  const iframeSrc = useMemo(() => {
+    if (!parsedUrl) return null
+    return `https://open.spotify.com/embed/${parsedUrl.type}/${parsedUrl.id}`
+  }, [parsedUrl])
+
+  useEffect(() => {
+    if (!url) {
+      setErrorMessage(null)
+      setIsLoading(false)
+      setHasLoadedOnce(false)
+      return
+    }
+
+    if (!parsedUrl) {
+      setErrorMessage(INVALID_URL_MESSAGE)
+      setIsLoading(false)
+      setHasLoadedOnce(false)
+      return
+    }
+
+    setErrorMessage(null)
+    setIsLoading(true)
+    setHasLoadedOnce(false)
+  }, [parsedUrl, url])
+
+  const resolvedHeight = height ?? (parsedUrl?.type === 'track' ? 152 : 352)
+
+  return (
+    <div className={cn('relative w-full', className)}>
+      {!url && !errorMessage && (
+        <div className='border rounded-xl border-border bg-muted/40 text-muted-foreground p-4 text-sm'>
+          Collez un lien Spotify (morceau, album ou playlist) pour voir le lecteur.
+        </div>
+      )}
+
+      {errorMessage && (
+        <div className='border rounded-xl border-destructive/30 bg-destructive/10 text-destructive p-4 text-sm flex gap-2'>
+          <AlertTriangle className='h-5 w-5 shrink-0' aria-hidden />
+          <p>{errorMessage}</p>
+        </div>
+      )}
+
+      {iframeSrc && !errorMessage && (
+        <div className='relative overflow-hidden rounded-xl border border-border bg-card shadow-sm'>
+          <iframe
+            src={iframeSrc}
+            width='100%'
+            height={resolvedHeight}
+            frameBorder='0'
+            allow='autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture'
+            loading='lazy'
+            className='w-full rounded-xl'
+            onLoad={() => {
+              setIsLoading(false)
+              setHasLoadedOnce(true)
+            }}
+            onError={() => {
+              setErrorMessage(UNSUPPORTED_MESSAGE)
+              setIsLoading(false)
+            }}
+            title='Spotify embed'
+          />
+
+          {isLoading && (
+            <div className='absolute inset-0 flex items-center justify-center bg-background/70'>
+              <div className='flex items-center gap-2 rounded-full bg-background/90 px-3 py-2 shadow-sm'>
+                <Loader2 className='h-4 w-4 animate-spin' />
+                <span className='text-sm'>Chargement du player…</span>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {hasLoadedOnce && !isLoading && !iframeSrc && !errorMessage && (
+        <div className='border rounded-xl border-destructive/30 bg-destructive/10 text-destructive p-4 text-sm flex gap-2'>
+          <AlertTriangle className='h-5 w-5 shrink-0' aria-hidden />
+          <p>{UNSUPPORTED_MESSAGE}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/AudioEmbed/SpotifyEmbed.tsx
+++ b/components/AudioEmbed/SpotifyEmbed.tsx
@@ -34,10 +34,17 @@ const parseSpotifyUrl = (rawUrl?: string): { type: SpotifyType; id: string } | n
     if (!SPOTIFY_HOSTNAMES.has(url.hostname)) return null
 
     const segments = url.pathname.split('/').filter(Boolean)
-    const type = segments[0] as SpotifyType | undefined
-    const idWithQuery = segments[1]
 
-    if (!type || !SPOTIFY_TYPES.includes(type)) return null
+    // Spotify URLs may include locale or "embed" prefixes (e.g. /intl-fr/track/{id} or /embed/track/{id}).
+    const typeIndex = segments.findIndex((segment): segment is SpotifyType =>
+      (SPOTIFY_TYPES as readonly string[]).includes(segment)
+    )
+
+    if (typeIndex === -1) return null
+
+    const type = segments[typeIndex]
+    const idWithQuery = segments[typeIndex + 1]
+
     if (!idWithQuery) return null
 
     const id = idWithQuery.split('?')[0]

--- a/components/MetaEmbed/MetaEmbed.tsx
+++ b/components/MetaEmbed/MetaEmbed.tsx
@@ -1,0 +1,235 @@
+'use client'
+
+import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { AlertTriangle, Loader2 } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { Button } from '../ui/button'
+
+const detectPlatformFromUrl = (rawUrl: string): 'instagram' | 'facebook' | null => {
+  const normalized = rawUrl.toLowerCase()
+
+  if (normalized.includes('instagram.com')) return 'instagram'
+  if (normalized.includes('facebook.com') || normalized.includes('fb.watch')) return 'facebook'
+
+  return null
+}
+
+type EmbedResponse = {
+  html: string
+  platform: 'instagram' | 'facebook'
+}
+
+type MetaEmbedProps = {
+  url: string
+  className?: string
+}
+
+export const MetaEmbed = ({ url, className }: MetaEmbedProps) => {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [embed, setEmbed] = useState<EmbedResponse | null>(null)
+
+  const platform = useMemo(() => detectPlatformFromUrl(url), [url])
+
+  useEffect(() => {
+    let isCancelled = false
+
+    const fetchEmbed = async () => {
+      if (!url || !platform) {
+        setEmbed(null)
+        setError(null)
+        return
+      }
+
+      setLoading(true)
+      setError(null)
+
+      try {
+        const response = await fetch('/api/meta-oembed', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ url }),
+        })
+
+        if (isCancelled) return
+
+        if (!response.ok) {
+          const payload = await response.json().catch(() => null)
+          setError(payload?.error ?? "Impossible d'afficher l'embed (lien privé ou non autorisé).")
+          setEmbed(null)
+          return
+        }
+
+        const payload = (await response.json()) as EmbedResponse
+        setEmbed(payload)
+      } catch (fetchError) {
+        if (isCancelled) return
+        console.error(fetchError)
+        setError("Erreur réseau lors de l'appel à l'API Meta oEmbed.")
+        setEmbed(null)
+      } finally {
+        if (!isCancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    fetchEmbed()
+
+    return () => {
+      isCancelled = true
+    }
+  }, [platform, url])
+
+  useEffect(() => {
+    if (!embed?.html) return
+
+    const needsInstagram = embed.platform === 'instagram'
+    const needsFacebook = embed.platform === 'facebook'
+
+    if (needsInstagram) {
+      const existingScript = document.querySelector<HTMLScriptElement>(
+        'script[src="https://www.instagram.com/embed.js"]',
+      )
+
+      if (!existingScript) {
+        const script = document.createElement('script')
+        script.src = 'https://www.instagram.com/embed.js'
+        script.async = true
+        script.onload = () => {
+          ;(window as any)?.instgrm?.Embeds?.process?.()
+        }
+        document.body.appendChild(script)
+      } else {
+        ;(window as any)?.instgrm?.Embeds?.process?.()
+      }
+    }
+
+    if (needsFacebook) {
+      const existingScript = document.querySelector<HTMLScriptElement>(
+        'script[src^="https://connect.facebook.net/"]',
+      )
+
+      if (!existingScript) {
+        const script = document.createElement('script')
+        script.src = 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v12.0'
+        script.async = true
+        script.defer = true
+        script.crossOrigin = 'anonymous'
+        script.onload = () => {
+          ;(window as any)?.FB?.XFBML?.parse?.()
+        }
+        document.body.appendChild(script)
+      } else {
+        ;(window as any)?.FB?.XFBML?.parse?.()
+      }
+    }
+  }, [embed])
+
+  if (!url) return null
+
+  if (!platform) {
+    return (
+      <div className='flex gap-2 rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive'>
+        <AlertTriangle className='h-5 w-5 shrink-0' aria-hidden />
+        <p>Seuls les liens Instagram ou Facebook publics sont pris en charge.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn('flex w-full max-w-2xl flex-col gap-3', className)}>
+      {loading && (
+        <div className='flex items-center gap-2 text-sm text-muted-foreground'>
+          <Loader2 className='h-4 w-4 animate-spin' aria-hidden />
+          <span>Chargement de l&apos;aperçu officiel…</span>
+        </div>
+      )}
+
+      {error && (
+        <div className='flex gap-2 rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive'>
+          <AlertTriangle className='h-5 w-5 shrink-0' aria-hidden />
+          <p>{error}</p>
+        </div>
+      )}
+
+      {embed?.html && !error && (
+        <div
+          className='overflow-hidden rounded-xl border bg-card p-2 shadow-sm'
+          dangerouslySetInnerHTML={{ __html: embed.html }}
+        />
+      )}
+    </div>
+  )
+}
+
+type MetaEmbedFieldProps = {
+  className?: string
+  defaultUrl?: string
+  onSubmit?: (payload: { url: string; platform: 'instagram' | 'facebook' | null }) => void
+}
+
+export const MetaEmbedField = ({ className, defaultUrl = '', onSubmit }: MetaEmbedFieldProps) => {
+  const [draftUrl, setDraftUrl] = useState(defaultUrl)
+  const [previewUrl, setPreviewUrl] = useState(defaultUrl)
+
+  const platform = useMemo(() => detectPlatformFromUrl(previewUrl), [previewUrl])
+  const unsupported = previewUrl && !platform
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const nextUrl = draftUrl.trim()
+    setPreviewUrl(nextUrl)
+    onSubmit?.({ url: nextUrl, platform: detectPlatformFromUrl(nextUrl) })
+  }
+
+  return (
+    <Card className={cn('w-full', className)}>
+      <CardHeader>
+        <CardTitle>Coller le lien Instagram ou Facebook</CardTitle>
+        <CardDescription>
+          Collez un post public Instagram ou Facebook. Nous interrogeons l&apos;API Meta oEmbed (avec jeton protégé côté serveur)
+          et affichons le rendu officiel.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className='flex flex-col gap-4'>
+        <form className='flex flex-col gap-3' onSubmit={handleSubmit}>
+          <div className='flex flex-col gap-2'>
+            <Label htmlFor='meta-url'>Lien du post</Label>
+            <div className='flex flex-col gap-3 sm:flex-row'>
+              <Input
+                id='meta-url'
+                value={draftUrl}
+                onChange={(event) => setDraftUrl(event.target.value)}
+                placeholder='https://www.instagram.com/p/... ou https://www.facebook.com/...'
+                inputMode='url'
+                className='flex-1'
+              />
+              <Button type='submit' className='sm:w-36'>
+                Prévisualiser
+              </Button>
+            </div>
+            <p className='text-xs text-muted-foreground'>Seuls les posts publics sont éligibles. Les comptes non autorisés voient une erreur.</p>
+          </div>
+        </form>
+
+        {unsupported && (
+          <div className='flex gap-2 rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive'>
+            <AlertTriangle className='h-5 w-5 shrink-0' aria-hidden />
+            <p>Lien non reconnu. Merci d&apos;utiliser une URL Instagram ou Facebook.</p>
+          </div>
+        )}
+
+        <MetaEmbed url={previewUrl} />
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/MetaEmbed/README.md
+++ b/components/MetaEmbed/README.md
@@ -1,0 +1,50 @@
+# Composant Meta oEmbed (Instagram / Facebook)
+
+## Vue d'ensemble
+
+`MetaEmbed` et `MetaEmbedField` permettent d'afficher dynamiquement un post Instagram ou Facebook via l'API officielle Meta oEmbed.
+Le jeton d'application reste côté serveur (route `/api/meta-oembed`) et la prévisualisation affiche les messages d'erreur en cas de
+compte non autorisé ou de post privé.
+
+## Configuration requise
+
+- Créez un app token Meta et exposez-le côté serveur :
+
+```
+META_OEMBED_APP_TOKEN="{APP_ID}|{APP_SECRET}"
+```
+
+- Pour restreindre la feature aux testeurs tant que la Business Verification / App Review n'est pas validée :
+
+```
+META_OEMBED_RESTRICTED=true
+META_OEMBED_TESTER_EMAILS="dev1@exemple.com,dev2@exemple.com"
+```
+
+Quand `META_OEMBED_RESTRICTED=true`, un utilisateur connecté doit appartenir à la liste `META_OEMBED_TESTER_EMAILS`. Si la liste
+est vide, tout utilisateur authentifié est accepté.
+
+## Usage rapide
+
+```tsx
+import { MetaEmbedField } from '@/components/MetaEmbed/MetaEmbed'
+
+export default function Example() {
+  return <MetaEmbedField />
+}
+```
+
+### Utilisation directe du composant
+
+```tsx
+import { MetaEmbed } from '@/components/MetaEmbed/MetaEmbed'
+
+<MetaEmbed url="https://www.instagram.com/p/abc123/" />
+```
+
+## Notes de debug
+
+- Les posts privés ou issus de comptes non autorisés renvoient une erreur JSON affichée dans le composant.
+- Le HTML retourné contient les scripts officiels. Le composant charge les SDK Instagram/Facebook si nécessaire et relance
+  `instgrm.Embeds.process()` ou `FB.XFBML.parse()` après rendu.
+- Le cache est désactivé (`cache: 'no-store'`) sur la route API afin de refléter immédiatement les permissions Meta.

--- a/components/VideoPlayer/VideoEmbedField.tsx
+++ b/components/VideoPlayer/VideoEmbedField.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { FormEvent, useMemo, useState } from 'react'
+import ReactPlayer from 'react-player'
+
+import { cn } from '@/lib/utils'
+
+import { Button } from '../ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { AlertTriangle } from 'lucide-react'
+import { VideoPlayer } from './VideoPlayer'
+
+type VideoEmbedFieldProps = {
+  className?: string
+  defaultUrl?: string
+  onSubmit?: (payload: { url: string; playable: boolean }) => void
+}
+
+const isPlayable = (url: string) => ReactPlayer.canPlay(url)
+
+export const VideoEmbedField = ({ className, defaultUrl = '', onSubmit }: VideoEmbedFieldProps) => {
+  const [draftUrl, setDraftUrl] = useState(defaultUrl)
+  const [previewUrl, setPreviewUrl] = useState(defaultUrl)
+
+  const playable = useMemo(() => (previewUrl ? isPlayable(previewUrl) : true), [previewUrl])
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const nextUrl = draftUrl.trim()
+    setPreviewUrl(nextUrl)
+    onSubmit?.({ url: nextUrl, playable: isPlayable(nextUrl) })
+  }
+
+  return (
+    <Card className={cn('w-full', className)}>
+      <CardHeader>
+        <CardTitle>Coller le lien de la vidéo</CardTitle>
+        <CardDescription>
+          Ajoutez une URL TikTok, YouTube ou un lien public compatible (MP4, Vimeo, etc.). Nous utilisons le lecteur vidéo pour
+          prévisualiser immédiatement le contenu.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className='flex flex-col gap-4'>
+        <form className='flex flex-col gap-3' onSubmit={handleSubmit}>
+          <div className='flex flex-col gap-2'>
+            <Label htmlFor='video-url'>Lien de la vidéo</Label>
+            <div className='flex flex-col gap-3 sm:flex-row'>
+              <Input
+                id='video-url'
+                value={draftUrl}
+                onChange={(event) => setDraftUrl(event.target.value)}
+                placeholder='https://www.tiktok.com/@user/video/123... ou https://youtube.com/watch?v=...'
+                inputMode='url'
+                className='flex-1'
+              />
+              <Button type='submit' className='sm:w-36'>
+                Prévisualiser
+              </Button>
+            </div>
+            <p className='text-xs text-muted-foreground'>Les liens publics sont nécessaires pour afficher la prévisualisation.</p>
+          </div>
+        </form>
+
+        {previewUrl && !playable && (
+          <div className='flex gap-2 rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive'>
+            <AlertTriangle className='h-5 w-5 shrink-0' aria-hidden />
+            <p>Le lien ne semble pas compatible. Essayez un URL TikTok, YouTube ou un flux vidéo lisible.</p>
+          </div>
+        )}
+
+        {previewUrl && playable && <VideoPlayer url={previewUrl} className='max-w-xl' />}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }


### PR DESCRIPTION
## Summary
- add reusable Spotify and SoundCloud embed components with loading and error states
- introduce audio embed form with tag and note capture plus automatic platform detection
- update embed preview page to showcase tweet and audio embeds together and document usage/testing cases

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f93c4ee948322850a5c107feaf516)